### PR TITLE
Keep paths in main bundle names to ensure unique bundle names, fixes #52

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tool",
   "version": "0.1.0",
   "devDependencies": {
-    "steal": "git://github.com/bitovi/steal#a6e7eda6cd99b96eb9e18ae4f6ccf6c80156dfea",
+    "steal": "git://github.com/asavoy/steal#771ee6840c396a91a5dbc1ae266c9648c6882d14",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -13,11 +13,15 @@ function getName(bundle) {
 		return (appName+"").replace(".js","");
 	});
 
-	// try with just the last part
 	var shortened = bundleNames.map(function(l){
 		return filename(l);
 	}).join('-');
 
+	// If this is a "main" bundle
+	if (bundle.bundles.length === 1 ) {
+		// Use the full path name, removing trailing ".js"
+		shortened = bundle.bundles[0].replace(".js", "");
+	}
 	var buildType = bundle.buildType || "js",
 		buildTypeSuffix = buildType === "js" ? "" : "."+buildType+"!";
 

--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -6,7 +6,9 @@ var winston = require('winston');
 var bundleFilename = require("./filename"),
   concatSource = require("../bundle/concat_source"),
   normalizeSource = require('./normalize_source'),
-  fs = require("fs");
+  fs = require("fs"),
+  mkdirp = require("fs-extra").mkdirp,
+  dirname = require("path").dirname;
 
 module.exports = function(bundles, configuration) {
   var bundlesDir = configuration.bundlesPath + "/";
@@ -35,11 +37,18 @@ module.exports = function(bundles, configuration) {
 
       // Once a folder has been created, write out the bundle source
       bundleDirDef.then(function() {
-        fs.writeFile(bundlePath, bundle.source, function(err) {
-          if(err) {
+        mkdirp(dirname(bundlePath), function(err) {
+          if (err) {
             reject(err);
-          } else {
-            resolve(bundle);
+          }
+          else {
+            fs.writeFile(bundlePath, bundle.source, function(err) {
+              if(err) {
+                reject(err);
+              } else {
+                resolve(bundle);
+              }
+            });
           }
         });
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean-css": "2.1.8",
     "colors": "^0.6.2",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#master",
+    "steal": "git://github.com/asavoy/steal#771ee6840c396a91a5dbc1ae266c9648c6882d14",
     "traceur": "0.0.45",
     "transpile": "git://github.com/bitovi/transpile#48eb67420cf16176d98167199a2341571f92d5df",
     "uglify-js": "~2.4.13",


### PR DESCRIPTION
Fixes #52.

Main bundle names should use the full path. If we only use the filename, we may conflict with other main bundles. 

Example: `users/list.js` and `tasks/list.js` would both be bundled to `bundles/list.js`; whichever is built last would overwrite the first.

With this fix, `users/list.js` would build to `bundles/users/list.js`, and `tasks/list.js` would build to `bundles/tasks/list.js`.

There may be other schemes to generate a bundle name but they a) are more complicated and/or b) can't guarantee uniqueness as well as just using the pathname.

**NOTE:** This also requires a matching change to StealJS' `steal.js` and `steal.production.js`. In `addProductionBundles()`:

    mainBundleName = bundlesDir+filename(main);

should become:

    mainBundleName = bundlesDir+main;

I'll submit a PR for that too. **EDIT:** Added a patch to steal here: https://github.com/bitovi/steal/pull/222
