### PR TITLE
RE #145 Add `.replace` call to normalize output of `bundlesPathURL` with...

### DIFF
--- a/lib/configuration/make.js
+++ b/lib/configuration/make.js
@@ -37,7 +37,7 @@ Configuration.prototype = {
 	 	return this.join( dir );
 	},
 	get bundlesPathURL () {
-		return path.relative( this.loader.baseURL, this.bundlesPath ).replace(/\//g, '/');
+		return path.relative( this.loader.baseURL, this.bundlesPath ).replace(/\\/g, '/');
 	},
 	mkBundlesPathDir: function(){
 		var bundlesPath = this.bundlesPath;

--- a/lib/configuration/make.js
+++ b/lib/configuration/make.js
@@ -37,7 +37,7 @@ Configuration.prototype = {
 	 	return this.join( dir );
 	},
 	get bundlesPathURL () {
-		return path.relative( this.loader.baseURL, this.bundlesPath );
+		return path.relative( this.loader.baseURL, this.bundlesPath ).replace(/\//g, '/');
 	},
 	mkBundlesPathDir: function(){
 		var bundlesPath = this.bundlesPath;


### PR DESCRIPTION
... forward slashes on all platforms.

