### PR TITLE
Adds --version option to cli

### DIFF
--- a/bin/steal
+++ b/bin/steal
@@ -9,8 +9,9 @@ var yargs = require("yargs")
 	.describe("bundle-steal", "Include steal.js in your main bundled JavaScript")
 	.describe("ignore", "For pluginify, a comma-separated list of modules to not include in the output")
 	.describe("out", "For pluginify, specify an output file")
-  .describe("verbose", "Verbose output")
-  .describe("quiet", "Quiet output")
+	.describe("verbose", "Verbose output")
+	.describe("quiet", "Quiet output")
+	.version(require("../package.json").version, "version")
 	.check(function(argv){
 		var command = argv._[0];
 


### PR DESCRIPTION
This is a simple change to add the `--version` option to the cli.

![screen shot 2015-02-03 at 10 53 30 pm](https://cloud.githubusercontent.com/assets/361671/6034928/7f660db0-abf7-11e4-9763-5925ed143676.png)
