### PR TITLE
Use proper output modules and throw error.

### DIFF
--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -167,7 +167,7 @@ module.exports = function(config, defaults, modules){
 					mods = out.output.modules;
 				} else if(typeof out.output.modules === "function"){
 					mods = out.output.modules(transform.loader);
-				} else {
+				} else if(out.output.modules) {
 					mods = [out.output.modules];
 				}
 				transformAndWriteOut(mods, out);

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -51,7 +51,7 @@ var transformImport = function(config, transformOptions){
 			
 			moduleNames.forEach(function(moduleName){
 				if(!data.graph[moduleName]){
-					throw "Can't find module '"+moduleName+"' in graph.";
+					throw new Error("Can't find module '" + moduleName + "' in graph.");
 				}
 			});
 			var nodesInBundle;


### PR DESCRIPTION
This bug cause the CanJS test pluginification to fail. The error was hard to discover because the Grunt task needed an instance of `Error` instead of a plain string.