### PR TITLE
Transpiles with 6to5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ test/pluginify_define/out.js
 test/pluginifier_builder_helpers/dist/
 test/pluginifier_builder_helpers/cjs/
 test/pluginifier_builder_helpers/browserify-out.js
+test/6to5/dist

--- a/lib/graph/transpile.js
+++ b/lib/graph/transpile.js
@@ -36,6 +36,9 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 			if(opts.useNormalizedDependencies) {
 				opts.normalizeMap = depMap;
 			}
+			if(loader.transpiler) {
+				opts.compiler = loader.transpiler;
+			}
 			// make sure load has activeSource
 			var load = _.clone(node.load, true);
 			load.source = source || load.source;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lodash": "2.4.1",
     "steal": "git://github.com/bitovi/steal#b6cb08983d93990de36644dca7288b6efb50966c",
     "traceur": "0.0.58",
-    "transpile": "0.4.0-alpha.1",
+    "transpile": "git://github.com/bitovi/transpile#1ec2705dd0b2b268b4c01170072128be557ec938",
     "uglify-js": "~2.4.13",
     "winston": "^0.7.3",
     "yargs": "^1.2.2",

--- a/test/babel/config.js
+++ b/test/babel/config.js
@@ -1,0 +1,3 @@
+System.config({
+	transpiler: '6to5'
+});

--- a/test/babel/dep.js
+++ b/test/babel/dep.js
@@ -1,0 +1,3 @@
+export default function() {
+	return 'dep';
+};

--- a/test/babel/main.js
+++ b/test/babel/main.js
@@ -1,0 +1,5 @@
+import dep from 'dep';
+
+window.MODULE = {
+	dep: dep
+};

--- a/test/babel/prod.html
+++ b/test/babel/prod.html
@@ -1,0 +1,1 @@
+<script src="../../bower_components/steal/steal.js" data-config="config" data-main="main" data-env="production"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -683,6 +683,30 @@ describe("multi build", function(){
 		});
 	});
 
+	it("works with 6to5/babel", function(done){
+		// this test seems broken.
+		rmdir(__dirname + "/6to5/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/babel/config.js",
+				main: "main"
+			}, {
+				quiet: true,
+				minify: false
+			}).then(function(){
+				open("test/babel/prod.html",function(browser, close){
+					find(browser,"MODULE", function(module){
+						assert(true, "module");
+						assert(module.dep, "has jquerty");
+						assert(module.dep(), "hello jquerty", "correct function loaded");
+						close();
+					}, close);
+				}, done);
+			}, done);
+		});
+	});
+
 });
 
 describe("multi build with plugins", function(){


### PR DESCRIPTION
This adds support for using 6to5 as part of the build. Since this is defined in the build most of the work is done by transpile. All we have to do here is make sure the option which is on the loader is passed as a transpile option.