### PR TITLE
When ordering check that node exists

### DIFF
--- a/lib/graph/order.js
+++ b/lib/graph/order.js
@@ -4,7 +4,7 @@ module.exports = function(graph, name){
 	var order = 0;
 
 	function visit( node ) {
-		if ( node.order === undefined ) {
+		if ( node && node.order === undefined ) {
 			//prevent infinate loops
 			node.order = null;
 			node.dependencies.forEach(function( moduleName ) {

--- a/test/test.js
+++ b/test/test.js
@@ -134,6 +134,22 @@ describe('dependency graph', function(){
 			}).then(done);
 
 		});
+
+		describe("Order", function(){
+			it("works when a module is dependent on @empty", function(){
+				var graph = {
+					main: {
+						dependencies: ["@empty", "dep"]
+					},
+					dep: {
+						dependencies: []
+					}
+				};
+				orderGraph(graph, "main");
+				assert.equal(graph.dep.order, 0, "Dep is first");
+				assert.equal(graph.main.order, 1, "Main is second");
+			});
+		});
 	});
 });
 


### PR DESCRIPTION
When a module depends on `@empty` or other virtual modules build would break because those virtual modules are not part of the graph and order expects every dependency to be on the graph. The fix is to ignore modules not on the graph when doing ordering. Fixes #144