### PR TITLE
Support glob as value for System.bundle

### DIFF
--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -79,7 +79,8 @@ var makeBundleGraph = require("../graph/make_graph_with_bundles"),
 	addTraceurRuntime = require("../bundle/add_traceur_runtime"),
 	makeConfiguration = require("../configuration/make"),
 	splitGraphByModuleNames = require("../graph/split"),
-	getBundleForOnly = require("../bundle/get_for_only");
+	getBundleForOnly = require("../bundle/get_for_only"),
+	findBundles = require("../loader/find_bundle");
 
 module.exports = function(config, options){
 	options = _.assign({ // Defaults
@@ -119,7 +120,7 @@ module.exports = function(config, options){
 			order(dependencyGraph, moduleName);
 		});
 		
-		( data.loader.bundle || []).forEach(function(moduleName){
+		findBundles(data.loader).forEach(function(moduleName){
 			order(dependencyGraph, moduleName);
 		});
 

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -1,5 +1,6 @@
 var dependencyGraph = require("./make_graph");
 var _ = require("lodash");
+var findBundles = require("../loader/find_bundle");
 
 function addBundleOnEveryModule (graph, bundle){
 	for(var name in graph) {
@@ -46,7 +47,8 @@ module.exports = function(config){
 		addBundleOnEveryModule(masterGraph, main); 
 		
 		// Get the bundles of the loader
-		bundleNames = bundleNames.concat( ( data.steal.System.bundle || [] ).slice(0) );
+		var loader = data.steal.System;
+		bundleNames = bundleNames.concat(findBundles(loader).slice(0) );
 		
 		// Get the next bundle name and gets a graph for it.
 		// Merges those nodes into the masterGraph

--- a/lib/loader/find_bundle.js
+++ b/lib/loader/find_bundle.js
@@ -1,0 +1,38 @@
+var glob = require("glob").sync;
+
+module.exports = findBundles;
+
+/**
+ * @module {Function} findBundles
+ * @description Find all of the bundles belonging to a loader.
+ * @param {Loader} loader
+ * @return {Array.<moduleName>}
+ */
+function findBundles(loader) {
+	if(Array.isArray(loader.bundle)) {
+		return loader.bundle;
+	} else if(typeof loader.bundle !== "string") {
+		return [];
+	}
+
+	// Support for globs,
+	// System.bundle = "components/**/*";
+	var pattern = loader.bundle;
+	var bundle = glob(pattern, {
+		cwd: path(loader.baseURL)
+	}).map(minusJS);
+
+	return bundle;
+}
+
+// Remove the file: protocol portion of the baseURL because glob doesn't
+// work with it.
+function path(baseURL) {
+	return baseURL.replace("file:", "");
+}
+
+// Remove the .js extension to make these proper module names.
+function minusJS(name) {
+	var idx = name.indexOf(".js");
+	return idx === -1 ? name : name.substr(0, idx);
+}

--- a/package.json
+++ b/package.json
@@ -10,16 +10,17 @@
   "dependencies": {
     "clean-css": "2.1.8",
     "colors": "^0.6.2",
+    "fs-extra": "~0.8.1",
+    "glob": "^4.3.5",
+    "less": "^1.7.0",
     "lodash": "2.4.1",
     "steal": "git://github.com/bitovi/steal#460a11629c5964c018867310baae1ba29a81eb43",
+    "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "0.4.0-alpha.1",
     "uglify-js": "~2.4.13",
     "winston": "^0.7.3",
-    "yargs": "^1.2.2",
-    "fs-extra" :"~0.8.1",
-    "less": "^1.7.0",
-    "system-parse-amd": "0.0.2"
+    "yargs": "^1.2.2"
   },
   "devDependencies": {
     "bower": "1.3.8",

--- a/test/test.js
+++ b/test/test.js
@@ -138,7 +138,6 @@ describe('dependency graph', function(){
 });
 
 describe("bundle", function(){
-
 	it("should work", function(done){
 
 		bundle({
@@ -155,6 +154,21 @@ describe("bundle", function(){
 		});
 	});
 
+	it("works with globs", function(done){
+		bundle({
+			config: __dirname+"/bundle/stealconfig.js",
+			main: "bundle",
+			logLevel: 3,
+			bundle: "app_*"
+		}).then(function(data){
+			var graphCompare = require('./bundle/bundle_graph');
+			comparify(data.graph, graphCompare, true);
+			done();
+
+		}).catch(function(e){
+			done(e)
+		});
+	});
 });
 
 


### PR DESCRIPTION
This allows `System.bundle` to be either an array or a glob. If a glob we'll look in the `baseURL` for files that match the glob pattern and use those as the modules for the bundle option. Fixes https://github.com/bitovi/steal/issues/316

Woops, forgot docs, will reopen after I've done that.