### PR TITLE
Fix multi-main test

### DIFF
--- a/test/multi-main/bundle_app_a.html
+++ b/test/multi-main/bundle_app_a.html
@@ -1,3 +1,4 @@
-<script src="./dist/bundles/app_a.js" 
+<script src="./dist/bundles/app_a.js"
+		data-config="config.js"
 		data-base-url="./" 
 		env="production"></script>


### PR DESCRIPTION
One of the multi-main tests was failing because the test didn't specify a config file so it was trying to load stealconfig.js

We've been getting this for a while:

```
Running "simplemocha:app" (simplemocha) task
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․Error loading "@config" at http://localhost:8081/test/multi-main/stealconfig.js
Not Found: http://localhost:8081/test/multi-main/stealconfig.js
․․․․․․․․․․․․․
```