### PR TITLE
Upgrade less to 2.4.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,6 @@
   "devDependencies": {
     "steal": "bitovi/steal#v0.7.0-pre.4",
     "jquery": "~1.10.0",
-	"less" : "^1.7.0"
+    "less" : "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "colors": "^0.6.2",
     "fs-extra": "~0.8.1",
     "glob": "^4.3.5",
-    "less": "^1.7.0",
+    "less": "^2.4.0",
     "lodash": "2.4.1",
     "steal": "git://github.com/bitovi/steal#v0.7.0-pre.4",
     "system-parse-amd": "0.0.2",


### PR DESCRIPTION
Point steal to the branch where the less plugin was updated.

Closes #166.