### PR TITLE
Normalize main and bundles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.5.0",
   "devDependencies": {
-    "steal": "bitovi/steal#7def481c1c02d11fa6102e87523b51943c59ee00",
+    "steal": "bitovi/steal#v0.7.0-pre.4",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.5.0",
   "devDependencies": {
-    "steal": "bitovi/steal#v0.7.0-pre.2",
+    "steal": "bitovi/steal#new-system-npm",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.5.0",
   "devDependencies": {
-    "steal": "bitovi/steal#new-system-npm",
+    "steal": "bitovi/steal#73c240d4ec53b4815c5e5ca5b14a0db83d2d55cf",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.5.0",
   "devDependencies": {
-    "steal": "bitovi/steal#73c240d4ec53b4815c5e5ca5b14a0db83d2d55cf",
+    "steal": "bitovi/steal#7def481c1c02d11fa6102e87523b51943c59ee00",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -149,17 +149,19 @@ module.exports = function(config, defaults, modules){
 			// write out the graphs
 			} else if(out.output.graphs){
 				if(typeof out.output.graphs === "function") {
-					mods = out.output.graphs(transform.loader);
+					mods = normalized(out.output.graphs(transform.loader), transform.loader);
 				} else {
-					mods = out.output.graphs;
+					mods = normalized(out.output.graphs, transform.loader);
 				}
 	
-				var ignores = transformImport.getAllIgnores(out.output.ignore, transform.graph);
-				
-				eachGraph(transform.graph, mods, function(name, node){
-					if(!transformImport.matches(ignores, name, node.load)) {
-						transformAndWriteOut(name, out, {ignoreAllDependencies: true});
-					}
+				Promise.all(mods).then(function(mods) {
+					var ignores = transformImport.getAllIgnores(out.output.ignore, transform.graph);
+					
+					eachGraph(transform.graph, mods, function(name, node){
+						if(!transformImport.matches(ignores, name, node.load)) {
+							transformAndWriteOut(name, out, {ignoreAllDependencies: true});
+						}
+					});
 				});
 			// write out all the modules combined
 			} else {
@@ -170,7 +172,17 @@ module.exports = function(config, defaults, modules){
 				} else if(out.output.modules) {
 					mods = [out.output.modules];
 				}
-				transformAndWriteOut(mods, out);
+				var modPromise = normalized(mods, transform.loader);
+				Promise.all(modPromise).then(function(mods) {
+					transformAndWriteOut(mods, out);
+				});
+			}
+
+			// Give an array of moduleNames, normalize them.
+			function normalized(mods, loader) {
+				return (mods || []).map(function(moduleName) {
+					return loader.normalize(moduleName);
+				});
 			}
 			
 		};

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -102,7 +102,7 @@ module.exports = function(config, options){
 	return makeBundleGraph(config).then(function(data){
 		var dependencyGraph = data.graph,
 			// the apps we are building
-			mains = Array.isArray( config.main ) ? config.main.slice(0) : [data.loader.main],
+			mains = Array.isArray(config.main) ? config.main.slice(0) : [data.loader.main],
 			configuration = makeConfiguration(data.loader, data.buildLoader, options);
 
 		// Remove @config so it is not transpiled.  It is a global,

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -182,6 +182,8 @@ module.exports = function(config, options){
 		var allBundles = splitMainBundles.concat(splitBundles);
 		// Name each bundle so we know what to call the bundle.
 		allBundles.forEach(nameBundle);
+		// Make sure the main bundle doesn't have an npm-normalized name
+		mainJSBundles.forEach(nameBundle.denpmed);
 
 		// Create a lookup object of the main bundle names so that they are
 		// excluded from the Bundles config

--- a/lib/bundle/filename.js
+++ b/lib/bundle/filename.js
@@ -10,6 +10,13 @@ module.exports = function(bundle){
 		}
 		
 	} else {
-		return bundle.name.replace(/^bundles\//,"")+".js";
+		return denpm(bundle.name).replace(/^bundles\//,"")+".js";
 	}
 };
+
+function denpm(name) {
+	if(/.+@.+#.+/.test(name)) {
+		return name.substr(name.lastIndexOf("#") + 1);
+	}
+	return name;
+}

--- a/lib/bundle/filename.js
+++ b/lib/bundle/filename.js
@@ -10,13 +10,6 @@ module.exports = function(bundle){
 		}
 		
 	} else {
-		return denpm(bundle.name).replace(/^bundles\//,"")+".js";
+		return bundle.name.replace(/^bundles\//,"")+".js";
 	}
 };
-
-function denpm(name) {
-	if(/.+@.+#.+/.test(name)) {
-		return name.substr(name.lastIndexOf("#") + 1);
-	}
-	return name;
-}

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -45,9 +45,17 @@ function getName(bundle) {
 	}
 }
 
-module.exports = function(bundle) {
+function denpmed(bundle) {
+	var name = getName(bundle);
+	if(/.+@.+#.+/.test(name)) {
+		bundle.name = name.substr(name.lastIndexOf("#") + 1);
+	}
+	return bundle.name;
+}
+
+exports = module.exports = function(bundle) {
 	bundle.name = getName(bundle);
 };
 
-module.exports.getName = getName;
-
+exports.getName = getName;
+exports.denpmed = denpmed;

--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -103,10 +103,17 @@ module.exports = function(config){
 		var appPromise = localSteal.startup(localConfig);
 
 		return appPromise.then(function(){
-			return Promise.all(depPromises).then(function(){
+			return Promise.all(depPromises)
+				.then(function() {
+					var main = localSteal.System.main;
+					return Promise.resolve(localSteal.System.normalize(main)).then(function(main) {
+						localSteal.System.main = main;
+					});
+				})
+				.then(function(){
 				global.System = oldGlobalSystem;
 				makePredefinedPluginDependencies(graph);
-				
+
 				return { 
 					graph: graph, 
 					steal: localSteal, 

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -1,6 +1,6 @@
 var dependencyGraph = require("./make_graph");
 var _ = require("lodash");
-var findBundles = require("../loader/find_bundle");
+var normalizeBundle = require("../loader/normalize_bundle");
 
 function addBundleOnEveryModule (graph, bundle){
 	for(var name in graph) {
@@ -38,7 +38,11 @@ module.exports = function(config){
 		cfg.main = bundleNames.shift();
 	}
 	// Get the first dependency graph
-	return dependencyGraph(cfg).then(function(data){
+	return dependencyGraph(cfg)
+		.then(normalizeBundle)
+		.then(function(data){
+
+		// TODO I left off here, need to make sure main is normalized.
 		
 		var masterGraph = data.graph,
 			main = data.steal.System.main;
@@ -48,7 +52,7 @@ module.exports = function(config){
 		
 		// Get the bundles of the loader
 		var loader = data.steal.System;
-		bundleNames = bundleNames.concat(findBundles(loader).slice(0) );
+		bundleNames = bundleNames.concat(loader.bundle.slice(0));
 		
 		// Get the next bundle name and gets a graph for it.
 		// Merges those nodes into the masterGraph
@@ -61,7 +65,8 @@ module.exports = function(config){
 					graph: masterGraph,
 					steal: data.steal,
 					loader: data.loader,
-					buildLoader: data.buildLoader
+					buildLoader: data.buildLoader,
+					mains: data.mains
 				};
 			} else {
 				var copy = _.clone(cfg, true);

--- a/lib/loader/normalize_bundle.js
+++ b/lib/loader/normalize_bundle.js
@@ -1,0 +1,27 @@
+var findBundle = require("./find_bundle");
+
+module.exports = function normalizeBundle(data) {
+	var loader = getLoader(data);
+	var bundle = findBundle(loader);
+
+	var normalizePromises = bundle.map(function(moduleName){
+		return Promise.resolve(loader.normalize(moduleName));
+	});
+
+	return Promise.all(normalizePromises).then(function(bundle){
+		loader.bundle = bundle;
+		return data;
+	});
+};
+
+// We could directly receive a loader or this might be a dependencyGraph object
+// containing the loader.
+function getLoader(data) {
+	if(typeof Loader !== "undefined" && (data instanceof global.Loader)) {
+		return data;
+	} else if(typeof LoaderPolyfill !== "undefined" && (data instanceof global.LoaderPolyfill)) {
+		return data;
+	} else {
+		return data.steal.System;
+	}
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^1.7.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#v0.7.0-pre.2",
+    "steal": "git://github.com/bitovi/steal#new-system-npm",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "git://github.com/bitovi/transpile#v0.5.0-pre.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-simple-mocha": "^0.4.0",
     "mocha": "1.18.2",
     "rimraf": "2.1",
-    "zombie": "2.0.0-alpha27",
+    "zombie": "2.5.1",
     "jquery": ">2.0",
     "browserify": "~8.1.0",
     "cssify": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^1.7.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#new-system-npm",
+    "steal": "git://github.com/bitovi/steal#73c240d4ec53b4815c5e5ca5b14a0db83d2d55cf",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "git://github.com/bitovi/transpile#v0.5.0-pre.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^1.7.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#73c240d4ec53b4815c5e5ca5b14a0db83d2d55cf",
+    "steal": "git://github.com/bitovi/steal#7def481c1c02d11fa6102e87523b51943c59ee00",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "git://github.com/bitovi/transpile#v0.5.0-pre.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^1.7.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#7def481c1c02d11fa6102e87523b51943c59ee00",
+    "steal": "git://github.com/bitovi/steal#v0.7.0-pre.4",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "git://github.com/bitovi/transpile#v0.5.0-pre.0",

--- a/test/npm/package.json
+++ b/test/npm/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "npm-test",
+  "version": "0.0.1",
   "main": "main",
   "dependencies": {
     "jquery": ">2.0"

--- a/test/npm/prod-bundle.html
+++ b/test/npm/prod-bundle.html
@@ -1,0 +1,6 @@
+
+<body>
+	<script src="./node_modules/steal/steal.js"
+		data-env="production"
+		data-main="main"></script>
+</body>

--- a/test/npm/src/three.js
+++ b/test/npm/src/three.js
@@ -1,0 +1,3 @@
+export function three() {
+	return "three";
+}

--- a/test/npm/src/two.js
+++ b/test/npm/src/two.js
@@ -1,0 +1,3 @@
+export function two() {
+	return "two";
+}

--- a/test/pluginifier_builder_helpers/src/tabs.js
+++ b/test/pluginifier_builder_helpers/src/tabs.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-import "tabs.less!";
+import "./tabs.less!";
 
 $.fn.tabs = function(){
 	this.addClass("tabs").text("tabs!");

--- a/test/test.js
+++ b/test/test.js
@@ -737,6 +737,43 @@ describe("multi build", function(){
 		});
 	});
 
+	it("works with an unnormalized main", function(done){
+		rmdir(__dirname+"/dist", function(error){
+			if(error){
+				done(error)
+			}
+
+			multiBuild({
+				config: __dirname+"/stealconfig.js",
+				main: "basics/"
+			}, {
+				quiet: true,
+				minify: false
+			}).then(function(data){
+				open("test/basics/prod.html",function(browser, close){
+					find(browser,"MODULE", function(module){
+						assert(true, "module");
+						
+						assert.equal(module.name, "module", "module name is right");
+		
+						assert.equal(module.es6module.name, "es6Module", "steal loads ES6");
+						
+						assert.equal(module.es6module.amdModule.name, "amdmodule", "ES6 loads amd");
+						
+						close();
+					}, close);
+				}, done);
+
+
+			}, done);
+
+
+
+		});
+	
+	});
+
+
 });
 
 describe("multi build with plugins", function(){
@@ -1483,16 +1520,14 @@ describe("export", function(){
 		
 		it("+cjs", function(done){
 			this.timeout(10000);
-			
+
 			stealExport({
-				
 				system: { config: __dirname+"/pluginifier_builder_helpers/package.json!npm" },
 				options: { quiet: true },
 				"outputs": {
 					"+cjs": {}
-				}
+				},
 			}).then(function(){
-
 				var browserify = require("browserify");
 				
 				var b = browserify();
@@ -1510,7 +1545,9 @@ describe("export", function(){
 				});
 				
 				
-			}, done);
+			}, function(e) {
+				done(e);
+			});
 				
 		});
 		

--- a/test/test.js
+++ b/test/test.js
@@ -1833,7 +1833,6 @@ describe("npm package.json builds", function(){
 					var h1s = browser.window.document.getElementsByTagName('h1');
 					assert.equal(h1s.length, 1, "Wrote H!.");
 					close();
-
 				}, done);
 
 			}).catch(done);

--- a/test/test.js
+++ b/test/test.js
@@ -1793,25 +1793,27 @@ describe("npm package.json builds", function(){
 	
 	var setup = function(done){
 		rmdir(__dirname+"/npm/node_modules", function(error){
-		
 			if(error){ return done(error); }
-		
-			fs.copy(
-				path.join(__dirname, "..", "node_modules","jquery"),
-				__dirname+"/npm/node_modules/jquery", function(error){
-					
-					if(error){ return done(error); }
-					
-					fs.copy(
-						path.join(__dirname, "..", "bower_components","steal"),
-						__dirname+"/npm/node_modules/steal", function(error){
-					
+			rmdir(__dirname+"/npm/dist", function(error){
+				if(error){ return done(error); }
+			
+				fs.copy(
+					path.join(__dirname, "..", "node_modules","jquery"),
+					__dirname+"/npm/node_modules/jquery", function(error){
+						
 						if(error){ return done(error); }
 						
-						done()
+						fs.copy(
+							path.join(__dirname, "..", "bower_components","steal"),
+							__dirname+"/npm/node_modules/steal", function(error){
 						
-					});
-					
+							if(error){ return done(error); }
+							
+							done()
+							
+						});
+						
+				});
 			});
 		});
 	};
@@ -1830,6 +1832,31 @@ describe("npm package.json builds", function(){
 				// open the prod page and make sure
 				// and make sure the module loaded successfully
 				open("test/npm/prod.html", function(browser, close){
+					var h1s = browser.window.document.getElementsByTagName('h1');
+					assert.equal(h1s.length, 1, "Wrote H!.");
+					close();
+				}, done);
+
+			}).catch(done);
+			
+		});
+
+	});
+
+	it("only needs a config and works with bundles", function(done){
+		setup(function(error){
+			if(error){ return done(error); }
+			
+			multiBuild({
+				config: __dirname + "/npm/package.json!npm",
+				bundle: ["npm-test/two", "npm-test/three"]
+			}, {
+				quiet: true,
+				minify: false
+			}).then(function(){
+				// open the prod page and make sure
+				// and make sure the module loaded successfully
+				open("test/npm/prod-bundle.html", function(browser, close){
 					var h1s = browser.window.document.getElementsByTagName('h1');
 					assert.equal(h1s.length, 1, "Wrote H!.");
 					close();


### PR DESCRIPTION
This updates the build process to normalize System.main in dependencyGraph so that users can pass unnormalized mains as the `main` option of `system`.

Also updates tests to work with the new directories.lib. Closes #168 and #89