### PR TITLE
Steal without versions extension

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.5.0",
   "devDependencies": {
-    "steal": "bitovi/steal#v0.7.0-pre.4",
+    "steal": "0.7.0-pre.5",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^2.4.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#v0.7.0-pre.4",
+    "steal": "git://github.com/bitovi/steal#v0.7.0-pre.5",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "git://github.com/bitovi/transpile#v0.5.0-pre.0",


### PR DESCRIPTION
This updates steal-tools to use a newer version of Steal without the versions extension, which interferes with the npm plugin.