### PR TITLE
Do not normalize special module names (fixes babel export)

### DIFF
--- a/lib/build/helpers/amd.js
+++ b/lib/build/helpers/amd.js
@@ -4,6 +4,12 @@ var path = require("path");
 
 var cjsCopy = baseHelper.extend({}, cjs);
 
+var pseudoModules = {
+	require: true,
+	exports: true,
+	module: true
+};
+
 /**
  * @module {function} steal-tools/lib/build/helpers/amd amd
  * @parent steal-tools.helpers
@@ -86,6 +92,11 @@ module.exports = (baseHelper.makeHelper(baseHelper.extend(cjsCopy, {
 	normalize: function(aliases){
 		aliases = aliases || {};
 		return function(depName, depLoad, curName, curLoad){
+			// If this is a special module like require or exports, doesn't
+			// need the normalization.
+			if(pseudoModules[depName] && !depLoad) {
+				return depName;
+			}
 			if(aliases[depName]) {
 				return aliases[depName];
 			}

--- a/lib/build/helpers/global.js
+++ b/lib/build/helpers/global.js
@@ -82,6 +82,9 @@ var make = function(buildType){
 		},
 		normalize: function(){
 			return function(depName, depLoad, curName, curLoad, loader){
+				if(!depLoad) {
+					return depName;
+				}
 				if( depLoad.address.indexOf("node_modules") >=0 ) {
 					return baseHelper.normalizeEndingSlash(depName);
 				} else {

--- a/lib/graph/transpile.js
+++ b/lib/graph/transpile.js
@@ -66,7 +66,10 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 						depLoad = load;
 					} else {
 						var normalizedName = options.useNormalizedDependencies ? name : depMap[name];
-						depLoad = graph[ normalizedName ].load;
+						var depNode = graph[normalizedName];
+						if(depNode) {
+							depLoad = depNode.load;
+						}
 					}
 					return givenNormalize.call(this, name, depLoad, curName, load, loader);
 				};

--- a/test/test.js
+++ b/test/test.js
@@ -1636,7 +1636,26 @@ describe("export", function(){
 				
 		});
 		
-		
+		it.only("+cjs +amd +global-css +global-js using Babel", function(done){
+			this.timeout(10000);
+			
+			stealExport({
+				
+				system: {
+					config: __dirname+"/pluginifier_builder_helpers/package.json!npm",
+					transpiler: "babel"
+				},
+				options: { quiet: true },
+				"outputs": {
+					"+cjs": {},
+					"+amd": {},
+					"+global-js": {},
+					"+global-css": {}
+				}
+			}).then(done, done);
+				
+		});
+	
 		
 		
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -1636,11 +1636,9 @@ describe("export", function(){
 				
 		});
 		
-		it.only("+cjs +amd +global-css +global-js using Babel", function(done){
+		it("+cjs +amd +global-css +global-js using Babel", function(done){
 			this.timeout(10000);
-			
 			stealExport({
-				
 				system: {
 					config: __dirname+"/pluginifier_builder_helpers/package.json!npm",
 					transpiler: "babel"
@@ -1653,10 +1651,7 @@ describe("export", function(){
 					"+global-css": {}
 				}
 			}).then(done, done);
-				
 		});
-	
-		
 		
 	});
 	


### PR DESCRIPTION
In AMD there are some special module names, `require`, `exports`, and `module` that do not need to be normalized and will throw if they are because they are not part of the dependency graph. Fixes #172