### PR TITLE
In make_graph normalized main can be an array.

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -106,8 +106,12 @@ module.exports = function(config){
 			return Promise.all(depPromises)
 				.then(function() {
 					var main = localSteal.System.main;
-					return Promise.resolve(localSteal.System.normalize(main)).then(function(main) {
-						localSteal.System.main = main;
+					var mains = Array.isArray(main) ? main : [main];
+					var normalizedPromises = mains.map(function(main){
+						return Promise.resolve(localSteal.System.normalize(main));
+					});
+					return Promise.all(normalizedPromises).then(function(main) {
+						localSteal.System.main = main.length > 1 ? main : main[0];
 					});
 				})
 				.then(function(){

--- a/test/test.js
+++ b/test/test.js
@@ -1423,6 +1423,51 @@ describe("export", function(){
 			
 		}, done);
 	});
+
+	it("works with multiple mains", function(done){
+		stealExport({
+			
+			system: {
+				main: [
+					"pluginifier_builder/pluginify",
+					"pluginifier_builder/common"
+				],
+				config: __dirname+"/stealconfig.js"
+			},
+			options: {
+				quiet: true
+			},
+			"outputs": {
+				"basics standalone": {
+					modules: ["basics/module/module"],
+					dest: function(){
+						return __dirname+"/out/basics.js"
+					},
+					minify: false
+				},
+				"pluginify without basics": {
+					modules: ["pluginifier_builder/pluginify"],
+					ignore: ["basics/module/module"],
+					dest: function(){
+						return __dirname+"/out/pluginify.js"
+					},
+					minify: false
+				}
+			}
+		}).then(function(){
+			open("test/pluginifier_builder/index.html", function(browser, close){
+	
+				find(browser,"RESULT", function(result){
+					assert.ok(result.module, "has module");
+					assert.ok(result.cjs,"has cjs module");
+					assert.equal(result.name, "pluginified");
+					close();
+				}, close);
+
+			}, done);
+			
+		}, done);
+	});
 	
 	it("passes the load objects to normalize and dest", function(done){
 		var destCalls = 0;


### PR DESCRIPTION
This fixes a regression caused by #169 and adds a test.

The scenario is exporting from multiple mains.  We normalize `main` in makeGraph but were not accounting for the possibility that main is an array. This fixes it and adds a test.