### PR TITLE
Export fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.7.0",
   "devDependencies": {
-    "steal": "bitovi/steal#v0.7.1-pre.1",
+    "steal": "bitovi/steal#map-and-paths",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "steal-tools",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "devDependencies": {
-    "steal": "0.7.0-pre.5",
+    "steal": "~0.7.0",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.7.0",
   "devDependencies": {
-    "steal": "bitovi/steal#ie8-fixes",
+    "steal": "bitovi/steal#v0.7.1-pre.1",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.7.0",
   "devDependencies": {
-    "steal": "bitovi/steal#map-and-paths",
+    "steal": "bitovi/steal#v0.7.1-pre.2",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -110,7 +110,11 @@ module.exports = function(config, defaults, modules){
 		
 		var transform,
 			transformAndWriteOut = function(moduleNames, out, extraOptions){
-				var outputOptions = _.assign(extraOptions||{},out.output);
+				extraOptions = extraOptions || {};
+				var outputOptions = _.assign(extraOptions, out.output, {
+					ignore: extraOptions.ignore || out.output.ignore
+				});
+				
 				var result = transform(moduleNames, outputOptions ),
 					filePath;
 				
@@ -133,56 +137,74 @@ module.exports = function(config, defaults, modules){
 			
 		var processOutput = function(out){
 			winston.info("OUTPUT: "+out.name);
-			
-			var mods;
+
+			var loader = transform.loader;
+			var mods, doTransform;
 			// write out each module and its dependencies in the list
 			if(out.output.eachModule) {
 				if(Array.isArray( out.output.eachModule) ) {
-					mods = normalized(out.output.eachModule, transform.loader);
+					mods = normalized(out.output.eachModule);
 				} else {
-					mods = normalized(_.map( _.where(modules, out.output.eachModule), "moduleName"), transform.loader);
+					mods = normalized(_.map( _.where(modules, out.output.eachModule), "moduleName"));
 				}
-				Promise.all(mods).then(function(mods){
+
+				doTransform = function(mods){
 					mods.forEach(function(mod){
 						transformAndWriteOut(mod, out);
 					});
-				});
+				};
 				
 			// write out the graphs
 			} else if(out.output.graphs){
 				if(typeof out.output.graphs === "function") {
-					mods = normalized(out.output.graphs(transform.loader), transform.loader);
+					mods = normalized(out.output.graphs(loader));
 				} else {
-					mods = normalized(out.output.graphs, transform.loader);
+					mods = normalized(out.output.graphs);
 				}
-	
-				Promise.all(mods).then(function(mods) {
-					var ignores = transformImport.getAllIgnores(out.output.ignore, transform.graph);
-					
+
+				doTransform = function(mods, ignores){
 					eachGraph(transform.graph, mods, function(name, node){
 						if(!transformImport.matches(ignores, name, node.load)) {
 							transformAndWriteOut(name, out, {ignoreAllDependencies: true});
 						}
 					});
-				});
+				};
 			// write out all the modules combined
 			} else {
 				if(Array.isArray( out.output.modules) ) {
-					mods = out.output.modules;
+					mods = normalized(out.output.modules);
 				} else if(typeof out.output.modules === "function"){
-					mods = out.output.modules(transform.loader);
+					mods = normalized(out.output.modules(loader));
 				} else if(out.output.modules) {
-					mods = [out.output.modules];
+					mods = normalized([out.output.modules]);
 				}
-				var modPromise = normalized(mods, transform.loader);
-				Promise.all(modPromise).then(function(mods) {
-					transformAndWriteOut(mods, out);
-				});
+				doTransform = function(mods, ignores){
+					transformAndWriteOut(mods, out, {
+						ignore: ignores
+					});
+				};
 			}
 
+			Promise.all(mods).then(function(mods) {
+				var ignore = out.output.ignore || [];
+				Promise.all(normalized(ignore))
+				.then(function(outputIgnore){
+					var ignores = transformImport.getAllIgnores(outputIgnore,
+																transform.graph);
+					doTransform(mods, ignores);
+				});
+			});
+
 			// Give an array of moduleNames, normalize them.
-			function normalized(mods, loader) {
+			function normalized(mods) {
+				if(mods && !Array.isArray(mods)) {
+					mods = [mods];
+				}
+
 				return (mods || []).map(function(moduleName) {
+					if(typeof moduleName === "function") {
+						return Promise.resolve(moduleName);
+					}
 					return loader.normalize(moduleName);
 				});
 			}

--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -138,12 +138,14 @@ module.exports = function(config, defaults, modules){
 			// write out each module and its dependencies in the list
 			if(out.output.eachModule) {
 				if(Array.isArray( out.output.eachModule) ) {
-					mods = out.output.eachModule;
+					mods = normalized(out.output.eachModule, transform.loader);
 				} else {
-					mods = _.map( _.where(modules, out.output.eachModule), "moduleName");
+					mods = normalized(_.map( _.where(modules, out.output.eachModule), "moduleName"), transform.loader);
 				}
-				mods.forEach(function(mod){
-					transformAndWriteOut(mod, out);
+				Promise.all(mods).then(function(mods){
+					mods.forEach(function(mod){
+						transformAndWriteOut(mod, out);
+					});
 				});
 				
 			// write out the graphs

--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -148,9 +148,11 @@ module.exports = function(config, defaults, modules){
 					mods = normalized(_.map( _.where(modules, out.output.eachModule), "moduleName"));
 				}
 
-				doTransform = function(mods){
+				doTransform = function(mods, ignores){
 					mods.forEach(function(mod){
-						transformAndWriteOut(mod, out);
+						transformAndWriteOut(mod, out, {
+							ignore: ignores					
+						});
 					});
 				};
 				

--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -67,6 +67,11 @@ var shim = function(exports, global){
 			};
 			args.push(require, module.exports, module);
 		}
+		// Babel uses only the exports objet
+		else if(!args[0] && deps[0] === "exports") {
+			module = { exports: {} };
+			args[0] = module.exports;
+		}
 
 		global.define = origDefine;
 		var result = callback ? callback.apply(null, args) : undefined;

--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -61,7 +61,8 @@ module.exports = function(config){
 			load.metadata.format= formatMap[load.metadata.format];
 		}
 		
-		winston.debug( (localSteal.System.systemName||"") +'+ ' + load.name+"-"+localSteal.System.bundle);
+		winston.debug( (localSteal.System.systemName||"") +'+ ' + load.name+ (
+			localSteal.System.bundle ? "-"+localSteal.System.bundle : ""));
 		// there could have been an old load from the BuildSystem
 		var oldLoad = graph[load.name];
 		

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^2.4.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#map-and-paths",
+    "steal": "git://github.com/bitovi/steal#v0.7.1-pre.2",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "steal-tools",
   "description": "Futuristic build tools for ES6 Module applications.",
-  "version": "0.6.0-pre.3",
+  "version": "0.7.0",
   "author": {
     "name": "Bitovi",
     "email": "contact@bitovi.com",
@@ -14,10 +14,10 @@
     "glob": "^4.3.5",
     "less": "^2.4.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#v0.7.0-pre.5",
+    "steal": "~0.7.0",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
-    "transpile": "git://github.com/bitovi/transpile#v0.5.0-pre.0",
+    "transpile": "~0.5.0",
     "uglify-js": "~2.4.13",
     "winston": "^0.7.3",
     "yargs": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^2.4.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#v0.7.1-pre.1",
+    "steal": "git://github.com/bitovi/steal#map-and-paths",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "glob": "^4.3.5",
     "less": "^2.4.0",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#ie8-fixes",
+    "steal": "git://github.com/bitovi/steal#v0.7.1-pre.1",
     "system-parse-amd": "0.0.2",
     "traceur": "0.0.58",
     "transpile": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   },
   "devDependencies": {
     "bower": "1.3.8",
+    "browserify": "~8.1.0",
     "comparify": "git://github.com/bitovi/comparify#master",
     "connect": "^2.14.4",
+    "cssify": "^0.6.0",
     "grunt": "~0.4.1",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "~0.3.0",
@@ -35,12 +37,11 @@
     "grunt-contrib-watch": "~0.3.0",
     "grunt-release": "^0.7.0",
     "grunt-simple-mocha": "^0.4.0",
-    "mocha": "1.18.2",
-    "rimraf": "2.1",
-    "zombie": "2.5.1",
     "jquery": ">2.0",
-    "browserify": "~8.1.0",
-    "cssify": "^0.6.0"
+    "mocha": "1.18.2",
+    "pdenodeify": "^0.1.0",
+    "rimraf": "2.1",
+    "zombie": "2.5.1"
   },
   "bin": {
     "steal-tools": "bin/steal"

--- a/test/npm/prod-global.html
+++ b/test/npm/prod-global.html
@@ -1,0 +1,14 @@
+<body>
+<script>
+	// jquery shim
+	window.$ = function(tag){
+		var el = document.getElementsByTagName(tag)[0];
+		return {
+			html: function(html){
+				el.innerHTML = html;
+			}
+		};
+	};
+</script>
+<script src="dist/global/npm-test.js"></script>
+</body>

--- a/test/npm/src/child.js
+++ b/test/npm/src/child.js
@@ -1,0 +1,3 @@
+export function foo(){
+
+};

--- a/test/npm/src/main.js
+++ b/test/npm/src/main.js
@@ -1,4 +1,9 @@
 import $ from "jquery";
+import * as child from "./child";
+
+window.MODULE = {
+	child: child
+};
 
 $("body").html("<h1>Hello World</h1>");
 

--- a/test/test.js
+++ b/test/test.js
@@ -1931,6 +1931,28 @@ describe("npm package.json builds", function(){
 		});
 
 	});
+
+	it("works with unnormalized modules", function(done){
+		var allModules = [
+			"npm-test/main",
+			"npm-test/two",
+			"npm-test/three"
+		];
+
+		stealExport({
+			system: {
+				config: __dirname+"/npm/package.json!npm",
+				main: allModules
+			},
+			options: { quiet: true },
+			"outputs": {
+				"+cjs": {
+					eachModule: allModules,
+					minify: false
+				},
+			}
+		}).then(done, done);
+	});
 	
 });
 


### PR DESCRIPTION
This has 2 fixes for steal-export:

1.  For global export, normalize to friendly names
2.  For eachModules, ignore the ignores.